### PR TITLE
Add ability to specify pvRequest in RPC client

### DIFF
--- a/src/org/epics/pvaccess/client/rpc/RPCClientFactory.java
+++ b/src/org/epics/pvaccess/client/rpc/RPCClientFactory.java
@@ -13,7 +13,7 @@ import org.epics.pvdata.pv.PVStructure;
 public class RPCClientFactory {
 	/**
 	 * Create a RPCClient and connect to the service.
-	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param serviceName The service name. This is the name of the channel that connects to the service.
 	 * @return The RPCClient interface.
 	 */
 	public static RPCClient create(String serviceName) {
@@ -22,7 +22,7 @@ public class RPCClientFactory {
 
 	/**
 	 * Create a RPCClient and connect to the service.
-	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param serviceName The service name. This is the name of the channel that connects to the service.
 	 * @param requester The RPCClientRequester interface implemented by the requester.
 	 * @return The RPCClient interface.
 	 */
@@ -32,7 +32,7 @@ public class RPCClientFactory {
 
 	/**
 	 * Create a RPCClient and connect to the service.
-	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param serviceName The service name. This is the name of the channel that connects to the service.
 	 * @param pvRequest  The structure sent in the request to create the Channel RPC.
 	 * @return The RPCClient interface.
 	 */
@@ -42,7 +42,7 @@ public class RPCClientFactory {
 
 	/**
 	 * Create a RPCClient and connect to the service.
-	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param serviceName The service name. This is the name of the channel that connects to the service.
 	 * @param pvRequest  The structure sent in the request to create the Channel RPC.
 	 * @param requester The RPCClientRequester interface implemented by the requester.
 	 * @return The RPCClient interface.

--- a/src/org/epics/pvaccess/client/rpc/RPCClientFactory.java
+++ b/src/org/epics/pvaccess/client/rpc/RPCClientFactory.java
@@ -3,6 +3,7 @@
  */
 package org.epics.pvaccess.client.rpc;
 
+import org.epics.pvdata.pv.PVStructure;
 
 /**
  * The factory to create a RPCClient.
@@ -27,6 +28,27 @@ public class RPCClientFactory {
 	 */
 	public static RPCClient create(String serviceName, RPCClientRequester requester) {
 		return new RPCClientImpl(serviceName,requester);
+	}
+
+	/**
+	 * Create a RPCClient and connect to the service.
+	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param pvRequest  The structure sent in the request to create the Channel RPC.
+	 * @return The RPCClient interface.
+	 */
+	public static RPCClient create(String serviceName, PVStructure pvRequest) {
+		return new RPCClientImpl(serviceName,pvRequest);
+	}
+
+	/**
+	 * Create a RPCClient and connect to the service.
+	 * @param serviceName The service name. This is the name of a PVRecord with associated support that implements the service.
+	 * @param pvRequest  The structure sent in the request to create the Channel RPC.
+	 * @param requester The RPCClientRequester interface implemented by the requester.
+	 * @return The RPCClient interface.
+	 */	 
+	public static RPCClient create(String serviceName, PVStructure pvRequest, RPCClientRequester requester) {
+		return new RPCClientImpl(serviceName,pvRequest,requester);
 	}
 
 }


### PR DESCRIPTION
Add ability to specify pvRequest in RPC client

Add overloads to RPCClient to allow the pvRequest sent in the channel RPC create to be specified. Send default request if not specified. This matches C++ behaviour.

Also improve the Javadoc for client.rpc. (Remove references to PVRecord - services may be provided in other ways).
